### PR TITLE
Update language definition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Haskell API for NATS messaging system (see https://github.com/derekcollison/nats
 
 Example use:
 
-```Haskell
+```haskell
 {-# LANGUAGE OverloadedStrings #-}
 import qualified Data.ByteString.Lazy as BL
 import Network.Nats


### PR DESCRIPTION
Using the lower case language definition for use with more restrictive Markdown parsers / code highlighters.

Specifically for display on http://nats.io
